### PR TITLE
Update Nomad to v0.10.4 to support new jobspec keys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,8 +20,8 @@ require (
 	github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/memberlist v0.1.5 // indirect
-	github.com/hashicorp/nomad v0.10.3
-	github.com/hashicorp/nomad/api v0.0.0-20191205150928-e2ce1eb2ea85
+	github.com/hashicorp/nomad v0.10.4
+	github.com/hashicorp/nomad/api v0.0.0-20200311202743-fa4137a9db62
 	github.com/hashicorp/raft v0.0.0-20170830143153-c837e57a6077 // indirect
 	github.com/hashicorp/serf v0.8.1 // indirect
 	github.com/hashicorp/terraform v0.10.5

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/hashicorp/hil v0.0.0-20170627220502-fa9f258a9250 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/memberlist v0.1.5 // indirect
-	github.com/hashicorp/nomad v0.9.6
+	github.com/hashicorp/nomad v0.10.3
 	github.com/hashicorp/nomad/api v0.0.0-20191205150928-e2ce1eb2ea85
 	github.com/hashicorp/raft v0.0.0-20170830143153-c837e57a6077 // indirect
 	github.com/hashicorp/serf v0.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/hashicorp/go-plugin v1.0.0 h1:/gQ1sNR8/LHpoxKRQq4PmLBuacfZb4tC93e9B30
 github.com/hashicorp/go-plugin v1.0.0/go.mod h1:++UyYGoz3o5w9ZzAdZxtQKrWWP+iqPBn3cQptSMzBuY=
 github.com/hashicorp/go-rootcerts v1.0.0 h1:Rqb66Oo1X/eSV1x66xbDccZjhJigjg0+e82kpwzSwCI=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
+github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
+github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-uuid v1.0.0 h1:RS8zrF7PhGwyNPOtxSClXXj9HA8feRnJzgnI1RJCSnM=
@@ -80,8 +82,12 @@ github.com/hashicorp/nomad v0.9.6 h1:igFz6wwgsBDjc2EgYMxvQgQLAZJp7A+cKmgZN8yiV68
 github.com/hashicorp/nomad v0.9.6/go.mod h1:WRaKjdO1G2iqi86TvTjIYtKTyxg4pl7NLr9InxtWaI0=
 github.com/hashicorp/nomad v0.10.3 h1:BuEjHuovoHAPdgI5GHhrHBNwR9Of6WA45dwpxeFHk3E=
 github.com/hashicorp/nomad v0.10.3/go.mod h1:WRaKjdO1G2iqi86TvTjIYtKTyxg4pl7NLr9InxtWaI0=
+github.com/hashicorp/nomad v0.10.4 h1:PPYawBHg95wN/2grlBSodImL9aYmehb7ZDcp8cYDN0k=
+github.com/hashicorp/nomad v0.10.4/go.mod h1:WRaKjdO1G2iqi86TvTjIYtKTyxg4pl7NLr9InxtWaI0=
 github.com/hashicorp/nomad/api v0.0.0-20191205150928-e2ce1eb2ea85 h1:s1Ux5pYNXfuLXOXR4sw4zT3ijEsvxkC2C7wHIHvlelw=
 github.com/hashicorp/nomad/api v0.0.0-20191205150928-e2ce1eb2ea85/go.mod h1:Kbx02dGxN6wnAHhSbTqeg/sdACnMMD20BFkVuAxJzds=
+github.com/hashicorp/nomad/api v0.0.0-20200311202743-fa4137a9db62 h1:Eq5tCgrP937vsrMszW8ksuElXHYQ//0y6e9zU5HMNgo=
+github.com/hashicorp/nomad/api v0.0.0-20200311202743-fa4137a9db62/go.mod h1:WKCL+tLVhN1D+APwH3JiTRZoxcdwRk86bWu1LVCUPaE=
 github.com/hashicorp/raft v0.0.0-20170830143153-c837e57a6077 h1:5LlsrNy18VSoEhUW810qqcyVtKB/m2/ppvGIMmOFWWk=
 github.com/hashicorp/raft v0.0.0-20170830143153-c837e57a6077/go.mod h1:DVSAWItjLjTOkVbSpWQ0j0kUADIvDaCtBxIcbNAQLkI=
 github.com/hashicorp/serf v0.8.1 h1:mYs6SMzu72+90OcPa5wr3nfznA4Dw9UyR791ZFNOIf4=
@@ -111,6 +117,8 @@ github.com/mitchellh/copystructure v0.0.0-20170525013902-d23ffcb85de3 h1:dECZqiJ
 github.com/mitchellh/copystructure v0.0.0-20170525013902-d23ffcb85de3/go.mod h1:eOsF2yLPlBBJPvD+nhl5QMTBSOBbOph6N7j/IDUw7PY=
 github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnGC8aR0=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
+github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77 h1:7GoSOOW2jpsfkntVKaS2rAr1TJqfcxotyaUcuxoZSzg=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,6 @@ github.com/hashicorp/memberlist v0.1.5 h1:AYBsgJOW9gab/toO5tEB8lWetVgDKZycqkebJ8
 github.com/hashicorp/memberlist v0.1.5/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/nomad v0.9.6 h1:igFz6wwgsBDjc2EgYMxvQgQLAZJp7A+cKmgZN8yiV68=
 github.com/hashicorp/nomad v0.9.6/go.mod h1:WRaKjdO1G2iqi86TvTjIYtKTyxg4pl7NLr9InxtWaI0=
-github.com/hashicorp/nomad v0.10.3 h1:BuEjHuovoHAPdgI5GHhrHBNwR9Of6WA45dwpxeFHk3E=
-github.com/hashicorp/nomad v0.10.3/go.mod h1:WRaKjdO1G2iqi86TvTjIYtKTyxg4pl7NLr9InxtWaI0=
 github.com/hashicorp/nomad v0.10.4 h1:PPYawBHg95wN/2grlBSodImL9aYmehb7ZDcp8cYDN0k=
 github.com/hashicorp/nomad v0.10.4/go.mod h1:WRaKjdO1G2iqi86TvTjIYtKTyxg4pl7NLr9InxtWaI0=
 github.com/hashicorp/nomad/api v0.0.0-20191205150928-e2ce1eb2ea85 h1:s1Ux5pYNXfuLXOXR4sw4zT3ijEsvxkC2C7wHIHvlelw=

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/hashicorp/memberlist v0.1.5 h1:AYBsgJOW9gab/toO5tEB8lWetVgDKZycqkebJ8
 github.com/hashicorp/memberlist v0.1.5/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/nomad v0.9.6 h1:igFz6wwgsBDjc2EgYMxvQgQLAZJp7A+cKmgZN8yiV68=
 github.com/hashicorp/nomad v0.9.6/go.mod h1:WRaKjdO1G2iqi86TvTjIYtKTyxg4pl7NLr9InxtWaI0=
+github.com/hashicorp/nomad v0.10.3 h1:BuEjHuovoHAPdgI5GHhrHBNwR9Of6WA45dwpxeFHk3E=
+github.com/hashicorp/nomad v0.10.3/go.mod h1:WRaKjdO1G2iqi86TvTjIYtKTyxg4pl7NLr9InxtWaI0=
 github.com/hashicorp/nomad/api v0.0.0-20191205150928-e2ce1eb2ea85 h1:s1Ux5pYNXfuLXOXR4sw4zT3ijEsvxkC2C7wHIHvlelw=
 github.com/hashicorp/nomad/api v0.0.0-20191205150928-e2ce1eb2ea85/go.mod h1:Kbx02dGxN6wnAHhSbTqeg/sdACnMMD20BFkVuAxJzds=
 github.com/hashicorp/raft v0.0.0-20170830143153-c837e57a6077 h1:5LlsrNy18VSoEhUW810qqcyVtKB/m2/ppvGIMmOFWWk=


### PR DESCRIPTION
I updated the nomad version dependency to v0.10.3, so the new jobspec keys would be supported when deploying via Levant, e.g. the volume-related keys.


I tried update to Nomad 0.10.4, but I got the following when building (in Linux).  This might just be a need to update some other dependency, but I gave up after a bit:
```
pkg/mod/github.com/hashicorp/nomad@v0.10.4/jobspec/parse_service.go:135:49: service.CanaryMeta undefined (type api.Service has no field or method CanaryMeta)
```


I was able to deploy a jobspec that included the volume key after this change.  Incidentally, I built it for Windows, and eveything seems to run fine, so you might be able to add Windows to the release binaries without much problem.

Should fix this issue: https://github.com/jrasell/levant/issues/323
Seems it may fix this issue as well: https://github.com/jrasell/levant/issues/324

