### PR TITLE
template: add toJSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.10 (Unreleased)
+
+IMPOROVEMENTS:
+ * Add `toJSON` template helper
+
 ## 0.2.9 (27 December 2019)
 
 IMPROVEMENTS:

--- a/template/funcs.go
+++ b/template/funcs.go
@@ -1,6 +1,7 @@
 package template
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -35,6 +36,7 @@ func funcMap(consulClient *consul.Client) template.FuncMap {
 		"timeNow":            timeNowFunc,
 		"timeNowUTC":         timeNowUTCFunc,
 		"timeNowTimezone":    timeNowTimezoneFunc(),
+		"toJSON":             toJSON,
 		"toLower":            toLower,
 		"toUpper":            toUpper,
 
@@ -229,6 +231,15 @@ func timeNowTimezoneFunc() func(string) (string, error) {
 
 		return time.Now().In(loc).Format("2006-01-02T15:04:05Z07:00"), nil
 	}
+}
+
+// toJSON converts the given structure into a deeply nested JSON string.
+func toJSON(i interface{}) (string, error) {
+	result, err := json.Marshal(i)
+	if err != nil {
+		return "", err
+	}
+	return string(bytes.TrimSpace(result)), err
 }
 
 func toLower(s string) (string, error) {


### PR DESCRIPTION
`toJSON` is very helpful to produce valid `env` values when the variable contains `#` or `\`

(This was stolen from consul-template, of course)