### PR TITLE
template: merge variable using mergo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/hashicorp/serf v0.8.1 // indirect
 	github.com/hashicorp/terraform v0.10.5
 	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
+	github.com/imdario/mergo v0.3.9
 	github.com/jmespath/go-jmespath v0.0.0-20151117175822-3433f3ea46d9 // indirect
 	github.com/mattn/go-isatty v0.0.2
 	github.com/mitchellh/cli v0.0.0-20170908181043-65fcae5817c8

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ github.com/hashicorp/terraform v0.10.5/go.mod h1:uN1KUiT7Wdg61fPwsGXQwK3c8PmpIVZ
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/imdario/mergo v0.3.9 h1:UauaLniWCFHWd+Jp9oCEkTBj8VO/9DKg3PV3VCNMDIg=
+github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/jmespath/go-jmespath v0.0.0-20151117175822-3433f3ea46d9 h1:1SlajWtS+u/6x2Be5vrHyrbSxkeIf/+ISBu//kmjpnc=
 github.com/jmespath/go-jmespath v0.0.0-20151117175822-3433f3ea46d9/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=

--- a/template/render.go
+++ b/template/render.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"path"
 
+	"github.com/imdario/mergo"
 	"github.com/jrasell/levant/client"
 	"github.com/jrasell/levant/helper"
 	"github.com/rs/zerolog/log"
@@ -80,8 +81,10 @@ func RenderTemplate(templateFile string, variableFiles []string, addr string, fl
 		if err != nil {
 			return
 		}
-		for k, v := range variables {
-			mergedVariables[k] = v
+
+		if err = mergo.Merge(&mergedVariables, variables, mergo.WithOverride); err != nil {
+			log.Debug().Msgf("template/render: error merging variables. %s", err)
+			return
 		}
 	}
 


### PR DESCRIPTION
Merge the var files using [mergo](https://github.com/imdario/mergo) so keys are merged rather than overwritten.

If you don't have one var-file it doesn't change a thing; if you have many clashing keys will now be merged rather that replaced. It might break stuff.