### PR TITLE
Making render logging consistent with other commands

### DIFF
--- a/command/render.go
+++ b/command/render.go
@@ -77,8 +77,8 @@ func (c *RenderCommand) Run(args []string) int {
 	flags.Usage = func() { c.UI.Output(c.Help()) }
 
 	flags.StringVar(&addr, "consul-address", "", "")
-	flags.StringVar(&level, "log-level", "DEBUG", "")
-	flags.StringVar(&format, "log-format", "JSON", "")
+	flags.StringVar(&level, "log-level", "INFO", "")
+	flags.StringVar(&format, "log-format", "HUMAN", "")
 	flags.Var((*helper.FlagStringSlice)(&variables), "var-file", "")
 	flags.StringVar(&outPath, "out", "", "")
 


### PR DESCRIPTION
Currently the render command logs at DEBUG in JSON format.  This PR would make the log level consistent with the other Levant commands.  It is a change in behavior so I isolated it as its own PR.