### PR TITLE
check task groups for the update stanza if not defined at the job level

### DIFF
--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -158,7 +158,7 @@ func (l *levantDeployment) deploy() (success bool) {
 
 		// If the service job doesn't have an update stanza, the job will not use
 		// Nomad deployments.
-		if l.config.Template.Job.Update == nil {
+		if !l.hasUpdateStanza() {
 			log.Info().Msg("levant/deploy: job is not configured with update stanza, consider adding to use deployments")
 			return l.jobStatusChecker(&eval.EvalID)
 		}
@@ -518,4 +518,24 @@ func (l *levantDeployment) isJobZeroCount() bool {
 		}
 	}
 	return true
+}
+
+// hasUpdateStanza checks if the job has an update stanza at the job level or for all task groups
+func (l *levantDeployment) hasUpdateStanza() (hasUpdate bool) {
+	if l.config.Template.Job.Update != nil {
+		hasUpdate = true
+		return
+	}
+
+	// Check if all task groups have an update stanza
+	if l.config.Template.Job.TaskGroups != nil {
+		hasUpdate = true
+		for _, taskGroup := range l.config.Template.Job.TaskGroups {
+			if taskGroup.Update == nil {
+				hasUpdate = false
+				return
+			}
+		}
+	}
+	return
 }

--- a/levant/deploy_test.go
+++ b/levant/deploy_test.go
@@ -1,0 +1,37 @@
+package levant
+
+import (
+	"github.com/hashicorp/levant/levant/structs"
+	nomad "github.com/hashicorp/nomad/api"
+	"testing"
+)
+
+func TestHasUpdateStanza(t *testing.T) {
+	ld1 := levantDeployment{config: &DeployConfig{Template: &structs.TemplateConfig{Job: &nomad.Job{
+		Update: nil}}}}
+	ld2 := levantDeployment{config: &DeployConfig{Template: &structs.TemplateConfig{Job: &nomad.Job{
+		Update: &nomad.UpdateStrategy{}}}}}
+	ld3 := levantDeployment{config: &DeployConfig{Template: &structs.TemplateConfig{Job: &nomad.Job{
+		Update: nil, TaskGroups: []*nomad.TaskGroup{{Update: nil}}}}}}
+	ld4 := levantDeployment{config: &DeployConfig{Template: &structs.TemplateConfig{Job: &nomad.Job{
+		Update: nil, TaskGroups: []*nomad.TaskGroup{{Update: &nomad.UpdateStrategy{}}}}}}}
+	ld5 := levantDeployment{config: &DeployConfig{Template: &structs.TemplateConfig{Job: &nomad.Job{
+		Update: nil, TaskGroups: []*nomad.TaskGroup{{Update: nil}, {Update: &nomad.UpdateStrategy{}}}}}}}
+
+	cases := []struct {
+		ld           levantDeployment
+		expectedTrue bool
+	}{
+		{ld1, false},
+		{ld2, true},
+		{ld3, false},
+		{ld4, true},
+		{ld5, false},
+	}
+
+	for _, c := range cases {
+		if c.ld.hasUpdateStanza() != c.expectedTrue {
+			t.Fatalf("expected hasUpdate to be %t, but got %t", c.ld.hasUpdateStanza(), c.expectedTrue)
+		}
+	}
+}


### PR DESCRIPTION
We have job specs with the update stanza defined only at the task group but levant only checks at the job level. This was raised as an issue in #145 

This PR modified the checking logic so that If an update stanza is not defined at the job level it will check all task groups and return true if they all contain an update stanza.