### PR TITLE
Fix typo in README sub-title

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 Welcome to the Levant documentation. The `docs` directory aims to host detailed and thorough documentation about Levant including design rational. Levant is an open source templating and deployment tool for [HashiCorp Nomad](https://www.nomadproject.io/) jobs that provides realtime feedback and detailed failure messages upon deployment issues.
 
-## Documentaion Pages
+## Documentation Pages
 
 * [Commands](./commands.md) - detail about the Levant CLI and flags associated with each command.
 * [Templates](./templates.md) - detail about Levant's templating engine and functions.


### PR DESCRIPTION
Fix a typo in the sub-title of the documentation README