### PR TITLE
job-checker: fix panic where job namespace is not set.

### DIFF
--- a/helper/nomad/opts.go
+++ b/helper/nomad/opts.go
@@ -1,0 +1,13 @@
+package nomad
+
+import "github.com/hashicorp/nomad/api"
+
+// GenerateBlockingQueryOptions generate Nomad API QueryOptions that can be
+// used for blocking. The namespace parameter will be set, if its non-nil.
+func GenerateBlockingQueryOptions(ns *string) *api.QueryOptions {
+	q := api.QueryOptions{WaitIndex: 1}
+	if ns != nil {
+		q.Namespace = *ns
+	}
+	return &q
+}

--- a/helper/nomad/opts_test.go
+++ b/helper/nomad/opts_test.go
@@ -1,0 +1,41 @@
+package nomad
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GenerateBlockingQueryOptions(t *testing.T) {
+	testCases := []struct {
+		inputNS        *string
+		expectedOutput *api.QueryOptions
+		name           string
+	}{
+		{
+			inputNS: nil,
+			expectedOutput: &api.QueryOptions{
+				WaitIndex: 1,
+			},
+			name: "nil input namespace",
+		},
+		{
+			inputNS: stringToPtr("non-default"),
+			expectedOutput: &api.QueryOptions{
+				WaitIndex: 1,
+				Namespace: "non-default",
+			},
+			name: "non-nil input namespace",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actualOutput := GenerateBlockingQueryOptions(tc.inputNS)
+			assert.Equal(t, tc.expectedOutput, actualOutput, tc.name)
+		})
+	}
+}
+
+func stringToPtr(s string) *string { return &s }

--- a/levant/job_status_checker.go
+++ b/levant/job_status_checker.go
@@ -1,6 +1,7 @@
 package levant
 
 import (
+	nomadHelper "github.com/hashicorp/levant/helper/nomad"
 	nomad "github.com/hashicorp/nomad/api"
 	"github.com/rs/zerolog/log"
 )
@@ -41,7 +42,7 @@ func (l *levantDeployment) jobStatusChecker(evalID *string) bool {
 // evaluations at least reach a job status of running.
 func (l *levantDeployment) simpleJobStatusChecker() bool {
 
-	q := &nomad.QueryOptions{WaitIndex: 1, Namespace: *l.config.Template.Job.Namespace}
+	q := nomadHelper.GenerateBlockingQueryOptions(l.config.Template.Job.Namespace)
 
 	for {
 
@@ -77,7 +78,7 @@ func (l *levantDeployment) simpleJobStatusChecker() bool {
 // jobs that do not support Nomad deployments.
 func (l *levantDeployment) jobAllocationChecker(evalID *string) bool {
 
-	q := &nomad.QueryOptions{WaitIndex: 1, Namespace: *l.config.Template.Job.Namespace}
+	q := nomadHelper.GenerateBlockingQueryOptions(l.config.Template.Job.Namespace)
 
 	// Build our small internal checking struct.
 	levantTasks := make(map[TaskCoordinate]string)


### PR DESCRIPTION
closes #368 