### PR TITLE
Switching default implementations to Sprig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 # Compiled Object files, Static and Dynamic libs (Shared Objects)
 *.o
 *.a
@@ -10,6 +12,7 @@ dist/
 
 # Build output directory.
 /bin
+/pkg
 
 # Architecture specific extensions/prefixes
 *.[568vq]


### PR DESCRIPTION
This PR changes the default function implementations to Sprig anyplace that there's a conflict.  The levant implementations are decorated with levant and upcased first letter of the function name, for example, the levant `env` function is renamed to `levantEnv`

Includes drive-by fix to add .DS_Store to .gitignore.
