### PR TITLE
cli: allow nested variables to be passed via var CLI flag.

### DIFF
--- a/command/deploy_test.go
+++ b/command/deploy_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestDeploy_checkCanaryAutoPromote(t *testing.T) {
 
-	fVars := make(map[string]string)
+	fVars := make(map[string]interface{})
 	depCommand := &DeployCommand{}
 	canaryPromote := 30
 
@@ -44,7 +44,7 @@ func TestDeploy_checkCanaryAutoPromote(t *testing.T) {
 
 func TestDeploy_checkForceBatch(t *testing.T) {
 
-	fVars := make(map[string]string)
+	fVars := make(map[string]interface{})
 	depCommand := &DeployCommand{}
 	forceBatch := true
 

--- a/command/meta.go
+++ b/command/meta.go
@@ -26,7 +26,7 @@ type Meta struct {
 	UI cli.Ui
 
 	// These are set by command-line flags
-	flagVars map[string]string
+	flagVars map[string]interface{}
 }
 
 // FlagSet returns a FlagSet with the common flags that every

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/hashicorp/consul/api v1.7.0
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-hclog v0.14.1 // indirect
+	github.com/hashicorp/go-multierror v1.1.0
 	github.com/hashicorp/go-uuid v1.0.2 // indirect
 	github.com/hashicorp/hcl/v2 v2.7.1
 	github.com/hashicorp/nomad v0.12.5-0.20201123213618-289d91df2e1c

--- a/helper/kvflag.go
+++ b/helper/kvflag.go
@@ -7,7 +7,7 @@ import (
 
 // Flag is a flag.Value implementation for parsing user variables
 // from the command-line in the format of '-var key=value'.
-type Flag map[string]string
+type Flag map[string]interface{}
 
 func (v *Flag) String() string {
 	return ""
@@ -22,11 +22,38 @@ func (v *Flag) Set(raw string) error {
 	}
 
 	if *v == nil {
-		*v = make(map[string]string)
+		*v = make(map[string]interface{})
 	}
 
-	key, value := raw[0:idx], raw[idx+1:]
-	(*v)[key] = value
+	// Split the variable key based on the nested delimiter to get a list of
+	// nested keys.
+	keys := strings.Split(raw[0:idx], ".")
+
+	// If we only have a single key, then we are not dealing with a nested set
+	// meaning we can update the variable mapping and exit.
+	if len(keys) == 1 {
+		(*v)[keys[0]] = raw[idx+1:]
+		return nil
+	}
+
+	// Identify the index max of the list for easy use.
+	nestedLen := len(keys) - 1
+
+	// The end map is the only thing we concretely know which contains our
+	// final key:value pair.
+	endEntry := map[string]interface{}{keys[nestedLen]: raw[idx+1:]}
+
+	// Track the root of the nested map structure so we can continue to iterate
+	// the nested keys below.
+	root := endEntry
+
+	// Iterate the nested keys backwards. Set a new root map containing the
+	// previous root as its value. Do not iterate backwards fully to the end,
+	// instead save the first key for the entry into Flag.
+	for i := nestedLen - 1; i > 0; i-- {
+		root = map[string]interface{}{keys[i]: root}
+	}
+	(*v)[keys[0]] = root
 	return nil
 }
 

--- a/helper/kvflag_test.go
+++ b/helper/kvflag_test.go
@@ -8,27 +8,29 @@ import (
 func TestHelper_Set(t *testing.T) {
 	cases := []struct {
 		Input  string
-		Output map[string]string
+		Output map[string]interface{}
 		Error  bool
 	}{
 		{
 			"key=value",
-			map[string]string{"key": "value"},
+			map[string]interface{}{"key": "value"},
 			false,
 		},
-
+		{
+			"nested.key=value",
+			map[string]interface{}{"nested": map[string]interface{}{"key": "value"}},
+			false,
+		},
 		{
 			"key=",
-			map[string]string{"key": ""},
+			map[string]interface{}{"key": ""},
 			false,
 		},
-
 		{
 			"key=foo=bar",
-			map[string]string{"key": "foo=bar"},
+			map[string]interface{}{"key": "foo=bar"},
 			false,
 		},
-
 		{
 			"key",
 			nil,
@@ -43,7 +45,7 @@ func TestHelper_Set(t *testing.T) {
 			t.Fatalf("bad error. Input: %#v", tc.Input)
 		}
 
-		actual := map[string]string(*f)
+		actual := map[string]interface{}(*f)
 		if !reflect.DeepEqual(actual, tc.Output) {
 			t.Fatalf("bad: %#v", actual)
 		}

--- a/helper/kvflag_test.go
+++ b/helper/kvflag_test.go
@@ -3,51 +3,90 @@ package helper
 import (
 	"reflect"
 	"testing"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHelper_Set(t *testing.T) {
 	cases := []struct {
-		Input  string
+		Label  string
+		Inputs []string
 		Output map[string]interface{}
 		Error  bool
 	}{
 		{
-			"key=value",
+			"simple value",
+			[]string{"key=value"},
 			map[string]interface{}{"key": "value"},
 			false,
 		},
 		{
-			"nested.key=value",
+			"nested replaces simple",
+			[]string{"key=1", "key.nested=2"},
+			nil,
+			true,
+		},
+		{
+			"simple replaces nested",
+			[]string{"key.nested=2", "key=1"},
+			map[string]interface{}{"key": "1"},
+			false,
+		},
+		{
+			"nested siblings",
+			[]string{"nested.a=1", "nested.b=2"},
+			map[string]interface{}{"nested": map[string]interface{}{"a": "1", "b": "2"}},
+			false,
+		},
+		{
+			"nested singleton",
+			[]string{"nested.key=value"},
 			map[string]interface{}{"nested": map[string]interface{}{"key": "value"}},
 			false,
 		},
 		{
-			"key=",
+			"nested with parent",
+			[]string{"root=a", "nested.key=value"},
+			map[string]interface{}{"root": "a", "nested": map[string]interface{}{"key": "value"}},
+			false,
+		},
+		{
+			"empty value",
+			[]string{"key="},
 			map[string]interface{}{"key": ""},
 			false,
 		},
 		{
-			"key=foo=bar",
+			"value contains equal sign",
+			[]string{"key=foo=bar"},
 			map[string]interface{}{"key": "foo=bar"},
 			false,
 		},
 		{
-			"key",
+			"missing equal sign",
+			[]string{"key"},
 			nil,
 			true,
 		},
 	}
 
 	for _, tc := range cases {
-		f := new(Flag)
-		err := f.Set(tc.Input)
-		if (err != nil) != tc.Error {
-			t.Fatalf("bad error. Input: %#v", tc.Input)
-		}
-
-		actual := map[string]interface{}(*f)
-		if !reflect.DeepEqual(actual, tc.Output) {
-			t.Fatalf("bad: %#v", actual)
-		}
+		t.Run(tc.Label, func(t *testing.T) {
+			f := new(Flag)
+			mErr := multierror.Error{}
+			for _, input := range tc.Inputs {
+				err := f.Set(input)
+				if err != nil {
+					mErr.Errors = append(mErr.Errors, err)
+				}
+			}
+			if tc.Error {
+				require.Error(t, mErr.ErrorOrNil())
+			} else {
+				actual := map[string]interface{}(*f)
+				require.True(t, reflect.DeepEqual(actual, tc.Output))
+			}
+		})
 	}
 }

--- a/helper/variable.go
+++ b/helper/variable.go
@@ -7,7 +7,7 @@ import (
 // VariableMerge merges the passed file variables with the flag variabes to
 // provide a single set of variables. The flagVars will always prevale over file
 // variables.
-func VariableMerge(fileVars *map[string]interface{}, flagVars *map[string]string) map[string]interface{} {
+func VariableMerge(fileVars, flagVars *map[string]interface{}) map[string]interface{} {
 
 	out := make(map[string]interface{})
 

--- a/helper/variable_test.go
+++ b/helper/variable_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestHelper_VariableMerge(t *testing.T) {
 
-	flagVars := make(map[string]string)
+	flagVars := make(map[string]interface{})
 	flagVars["job_name"] = "levantExample"
 	flagVars["datacentre"] = "dc13"
 

--- a/template/render.go
+++ b/template/render.go
@@ -29,7 +29,7 @@ type terraformVar struct {
 
 // RenderJob takes in a template and variables performing a render of the
 // template followed by Nomad jobspec parse.
-func RenderJob(templateFile string, variableFiles []string, addr string, flagVars *map[string]string) (job *nomad.Job, err error) {
+func RenderJob(templateFile string, variableFiles []string, addr string, flagVars *map[string]interface{}) (job *nomad.Job, err error) {
 	var tpl *bytes.Buffer
 	tpl, err = RenderTemplate(templateFile, variableFiles, addr, flagVars)
 	if err != nil {
@@ -41,7 +41,7 @@ func RenderJob(templateFile string, variableFiles []string, addr string, flagVar
 
 // RenderTemplate is the main entry point to render the template based on the
 // passed variables file.
-func RenderTemplate(templateFile string, variableFiles []string, addr string, flagVars *map[string]string) (tpl *bytes.Buffer, err error) {
+func RenderTemplate(templateFile string, variableFiles []string, addr string, flagVars *map[string]interface{}) (tpl *bytes.Buffer, err error) {
 
 	t := &tmpl{}
 	t.flagVariables = flagVars

--- a/template/render_test.go
+++ b/template/render_test.go
@@ -22,7 +22,7 @@ func TestTemplater_RenderTemplate(t *testing.T) {
 	var err error
 
 	// Start with an empty passed var args map.
-	fVars := make(map[string]string)
+	fVars := make(map[string]interface{})
 
 	// Test basic TF template render.
 	job, err = RenderJob("test-fixtures/single_templated.nomad", []string{"test-fixtures/test.tf"}, "", &fVars)

--- a/template/template.go
+++ b/template/template.go
@@ -10,7 +10,7 @@ import (
 // inbuilt functions.
 type tmpl struct {
 	consulClient    *consul.Client
-	flagVariables   *map[string]string
+	flagVariables   *map[string]interface{}
 	jobTemplateFile string
 	variableFiles   []string
 }

--- a/test/acctest/deploy.go
+++ b/test/acctest/deploy.go
@@ -12,7 +12,7 @@ import (
 type DeployTestStepRunner struct {
 	FixtureName string
 
-	Vars map[string]string
+	Vars map[string]interface{}
 
 	Canary     int
 	ForceBatch bool
@@ -22,7 +22,7 @@ type DeployTestStepRunner struct {
 // Run renders the job fixture and triggers a deployment
 func (c DeployTestStepRunner) Run(s *TestState) error {
 	if c.Vars == nil {
-		c.Vars = map[string]string{}
+		c.Vars = map[string]interface{}{}
 	}
 	c.Vars["job_name"] = s.JobName
 

--- a/test/deploy_test.go
+++ b/test/deploy_test.go
@@ -70,7 +70,7 @@ func TestDeploy_count(t *testing.T) {
 			{
 				Runner: acctest.DeployTestStepRunner{
 					FixtureName: "deploy_count.nomad",
-					Vars: map[string]string{
+					Vars: map[string]interface{}{
 						"count": "3",
 					},
 				},
@@ -79,7 +79,7 @@ func TestDeploy_count(t *testing.T) {
 			{
 				Runner: acctest.DeployTestStepRunner{
 					FixtureName: "deploy_count.nomad",
-					Vars: map[string]string{
+					Vars: map[string]interface{}{
 						"count": "1",
 					},
 				},
@@ -92,7 +92,7 @@ func TestDeploy_count(t *testing.T) {
 			{
 				Runner: acctest.DeployTestStepRunner{
 					FixtureName: "deploy_count.nomad",
-					Vars: map[string]string{
+					Vars: map[string]interface{}{
 						"count": "1",
 					},
 					ForceCount: true,
@@ -114,7 +114,7 @@ func TestDeploy_canary(t *testing.T) {
 				Runner: acctest.DeployTestStepRunner{
 					FixtureName: "deploy_canary.nomad",
 					Canary:      10,
-					Vars: map[string]string{
+					Vars: map[string]interface{}{
 						"env_version": "1",
 					},
 				},
@@ -124,7 +124,7 @@ func TestDeploy_canary(t *testing.T) {
 				Runner: acctest.DeployTestStepRunner{
 					FixtureName: "deploy_canary.nomad",
 					Canary:      10,
-					Vars: map[string]string{
+					Vars: map[string]interface{}{
 						"env_version": "2",
 					},
 				},


### PR DESCRIPTION
This change updates the way the var CLI flag is processed to allow
the use of nested variables in the form of nested.var=val. Until
now either side of the delimiter was evaluated simply as a string.

All tests have been updated and accomodate the change aongside the
acceptance tests.

closes #257 