### PR TITLE
if stdout isn't a terminal, send logging to stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## UNRELEASED 
+
+IMPROVEMENTS: 
+ * render: when rendering, send logging to stderr if stdout is not a terminal [[GH-386](https://github.com/hashicorp/levant/pull/386)]
+
 ## 0.3.0-beta1 (November 24, 2020)
 
 BUG FIXES:

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -60,7 +60,7 @@ func setLogFormat(format string) error {
 		isatty.IsCygwinTerminal(os.Stdout.Fd()) {
 		logWriter = conswriter.GetTerminal()
 	} else {
-		logWriter = os.Stdout
+		logWriter = os.Stderr
 	}
 
 	switch format {


### PR DESCRIPTION
seems like the simplest way to address this. i couldn't think of a scenario where a user would have been relying on logging going with the rendered file to stdout.