### PR TITLE
Fix panic when a job without update stanza fails deployment

### DIFF
--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -184,15 +184,17 @@ func (l *levantDeployment) deploy() (success bool) {
 			return
 		}
 
-		// If the job is not a canary job, then run the auto-revert checker, the
-		// current checking mechanism is slightly hacky and should be updated.
-		// The reason for this is currently the config.Job is populate from the
-		// rendered job and so a user could potentially not set canary meaning
-		// the field shows a null.
-		if l.config.Template.Job.Update.Canary == nil {
-			l.checkAutoRevert(dep)
-		} else if *l.config.Template.Job.Update.Canary == 0 {
-			l.checkAutoRevert(dep)
+		if l.config.Template.Job.Update != nil {
+			// If the job is not a canary job, then run the auto-revert checker, the
+			// current checking mechanism is slightly hacky and should be updated.
+			// The reason for this is currently the config.Job is populates from the
+			// rendered job and so a user could potentially not set canary meaning
+			// the field shows a null.
+			if l.config.Template.Job.Update.Canary == nil {
+				l.checkAutoRevert(dep)
+			} else if *l.config.Template.Job.Update.Canary == 0 {
+				l.checkAutoRevert(dep)
+			}
 		}
 
 	case nomad.JobTypeBatch:

--- a/test/deploy_test.go
+++ b/test/deploy_test.go
@@ -135,6 +135,21 @@ func TestDeploy_canary(t *testing.T) {
 	})
 }
 
+func TestDeploy_failed_deploy_with_no_update(t *testing.T) {
+	acctest.Test(t, acctest.TestCase{
+		Steps: []acctest.TestStep{
+			{
+				Runner: acctest.DeployTestStepRunner{
+					FixtureName: "deploy_fail_with_no_update.nomad",
+				},
+				ExpectErr: true,
+				Check:     acctest.CheckDeploymentStatus("failed"),
+			},
+		},
+		CleanupFunc: acctest.CleanupPurgeJob,
+	})
+}
+
 func TestDeploy_lifecycle(t *testing.T) {
 	acctest.Test(t, acctest.TestCase{
 		Steps: []acctest.TestStep{

--- a/test/fixtures/deploy_fail_with_no_update.nomad
+++ b/test/fixtures/deploy_fail_with_no_update.nomad
@@ -1,0 +1,58 @@
+job "[[.job_name]]" {
+  datacenters = ["dc1"]
+  type = "service"
+
+  group "test" {
+    count = 1
+
+    restart {
+      attempts = 1
+      interval = "5s"
+      delay = "1s"
+      mode = "fail"
+    }
+
+    ephemeral_disk {
+      size = 300
+    }
+
+    update {
+      max_parallel     = 1
+      min_healthy_time = "10s"
+      healthy_deadline = "1m"
+    }
+
+    network {
+      port "http" {
+        to = 80
+      }
+    }
+
+    service {
+      name = "fake-service"
+      port = "http"
+
+       check {
+         name     = "alive"
+         type     = "tcp"
+         interval = "10s"
+         timeout  = "2s"
+       }
+    }
+
+    task "alpine" {
+      driver = "docker"
+      config {
+        image = "alpine"
+        command = "sleep 1 && exit 1"
+      }
+      resources {
+        cpu    = 100
+        memory = 20
+        network {
+          mbits = 10
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Currently levant panics if there's a failed deployment for a job without
an update stanza.