### PR TITLE
Update example for `replace` function.

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -313,7 +313,7 @@ Replaces all occurrences of the search string with the replacement string.
 
 Example:
 ```
-[[ replace "Batman and Robin" "Robin" "Catwoman" ]]
+[[ "Batman and Robin" | replace "Robin" "Catwoman" ]]
 ```
 
 Render:


### PR DESCRIPTION
The phrase "Batman and Robin" should be piped into `replace` or set as the last parameter.  Closes #419