### PR TITLE
Typo in plan output

### DIFF
--- a/levant/plan.go
+++ b/levant/plan.go
@@ -57,7 +57,7 @@ func TriggerPlan(config *PlanConfig) (bool, bool) {
 	}
 
 	if !changes && lp.config.Plan.IgnoreNoChanges {
-		log.Info().Msg("levant/plan: no changes found in job but ignore-changes flag set to true")
+		log.Info().Msg("levant/plan: no changes found in job but ignore-no-changes flag set to true")
 	} else if !changes && !lp.config.Plan.IgnoreNoChanges {
 		log.Info().Msg("levant/plan: no changes found in job")
 		return false, changes


### PR DESCRIPTION
The option name is listed incorrectly (backwards, in fact) in the output of plan.