### PR TITLE
ci: fix nightly release

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -38,7 +38,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             try {
-                await github.git.deleteRef({
+                await github.rest.git.deleteRef({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   ref: "tags/nightly"
@@ -46,7 +46,7 @@ jobs:
             } catch (e) {
               console.log("Warning: The nightly tag doesn't exist yet, so there's nothing to do. Trace: " + e)
             }
-            await github.git.createRef({
+            await github.rest.git.createRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: "refs/tags/nightly",


### PR DESCRIPTION
The GHA version pinning PR upgraded several actions to their latest version, causing `actions/github-script` to fail due to some breaking changes.

Failed run: https://github.com/hashicorp/levant/actions/runs/4793342895
Successful run: https://github.com/hashicorp/levant/actions/runs/4853528583