### PR TITLE
ci: fix nightly release

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -87,4 +87,4 @@ jobs:
           status: failure
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
 permissions:
-  contents: read
+  contents: write


### PR DESCRIPTION
Has been failing for a couple months, since the permissions section was added. 

Need `contents:write` to create the nightly tag to base the prerelease on.

The error was a 403 during "Advance nightly tag" step:

```
RequestError [HttpError]: Resource not accessible by integration
```

I ran this change as a workflow_dispatch with success here: https://github.com/hashicorp/levant/actions/runs/5694313876/job/15435349938
resulting in a new nightly here: https://github.com/hashicorp/levant/releases