### PR TITLE
Update GitHub actions to current

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -8,6 +8,6 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: "Check workflow files"
         uses: docker://docker.mirror.hashicorp.services/rhysd/actionlint:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,10 @@ on:
   push:
   workflow_dispatch:
   workflow_call:
+
 env:
   PKG_NAME: "levant"
+
 jobs:
   get-go-version:
     name: "Determine Go toolchain version"
@@ -18,6 +20,7 @@ jobs:
         run: |
           echo "Building with Go $(cat .go-version)"
           echo "go-version=$(cat .go-version)" >> "$GITHUB_OUTPUT"
+
   get-product-version:
     runs-on: ubuntu-20.04
     outputs:
@@ -29,6 +32,7 @@ jobs:
         run: |
           make version
           echo "product-version=$(make version)" >> "$GITHUB_OUTPUT"
+
   generate-metadata-file:
     needs: get-product-version
     runs-on: ubuntu-20.04
@@ -39,16 +43,18 @@ jobs:
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Generate metadata file
         id: generate-metadata-file
-        uses: hashicorp/actions-generate-metadata@v1
+        uses: hashicorp/actions-generate-metadata@fdbc8803a0e53bcbb912ddeee3808329033d6357 # v1.1.1
         with:
           version: ${{ needs.get-product-version.outputs.product-version }}
           product: ${{ env.PKG_NAME }}
+          repository: ${{ env.PKG_NAME }}
           repositoryOwner: "hashicorp"
       - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: ${{ !env.ACT }}
         with:
           name: metadata.json
           path: ${{ steps.generate-metadata-file.outputs.filepath }}
+
   generate-ldflags:
     needs: get-product-version
     runs-on: ubuntu-20.04
@@ -88,7 +94,7 @@ jobs:
           GO_LDFLAGS: ${{ needs.generate-ldflags.outputs.ldflags }}
           CGO_ENABLED: "0"
           BIN_PATH: ${{ env.PKG_NAME }}_${{ needs.get-product-version.outputs.product-version }}_${{ matrix.goos }}_${{ matrix.goarch }}
-        uses: hashicorp/actions-go-build@v0.1.9
+        uses: hashicorp/actions-go-build@37358f6098ef21b09542d84a9814ebb843aa4e3e # v1.0.0
         with:
           product_name: ${{ env.PKG_NAME }}
           product_version: ${{ needs.get-product-version.outputs.product-version }}
@@ -99,7 +105,7 @@ jobs:
           instructions: |-
             make crt
       - if: ${{ matrix.goos == 'linux' }}
-        uses: hashicorp/actions-packaging-linux@v1
+        uses: hashicorp/actions-packaging-linux@0596d94121d44bd00463ac9d245efea64ee282d0 # v1.7.0
         with:
           name: "levant"
           description: "Levant is a templating and deployment tool for HashiCorp Nomad"
@@ -128,6 +134,7 @@ jobs:
           name: ${{ env.DEB_PACKAGE }}
           path: out/${{ env.DEB_PACKAGE }}
           if-no-files-found: error
+
   build-docker-default:
     needs:
       - get-product-version
@@ -143,7 +150,7 @@ jobs:
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Docker Build (Action)
-        uses: hashicorp/actions-docker-build@v1
+        uses: hashicorp/actions-docker-build@11d43ef520c65f58683d048ce9b47d6617893c9a # v2.0.0
         with:
           smoke_test: |
             TEST_VERSION="$(docker run "${IMAGE_NAME}" version | awk '/Levant/{print $2}')"
@@ -160,5 +167,6 @@ jobs:
           dev_tags: |
             docker.io/hashicorppreview/${{ env.PKG_NAME }}:${{ env.version }}-dev
             docker.io/hashicorppreview/${{ env.PKG_NAME }}:${{ env.version }}-${{ github.sha }}
+
 permissions:
   contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       go-version: ${{ steps.get-go-version.outputs.go-version }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Determine Go version
         id: get-go-version
         run: |
@@ -23,7 +23,7 @@ jobs:
     outputs:
       product-version: ${{ steps.get-product-version.outputs.product-version }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: get product version
         id: get-product-version
         run: |
@@ -36,7 +36,7 @@ jobs:
       filepath: ${{ steps.generate-metadata-file.outputs.filepath }}
     steps:
       - name: "Checkout directory"
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Generate metadata file
         id: generate-metadata-file
         uses: hashicorp/actions-generate-metadata@v1
@@ -44,7 +44,7 @@ jobs:
           version: ${{ needs.get-product-version.outputs.product-version }}
           product: ${{ env.PKG_NAME }}
           repositoryOwner: "hashicorp"
-      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: ${{ !env.ACT }}
         with:
           name: metadata.json
@@ -55,7 +55,7 @@ jobs:
     outputs:
       ldflags: ${{ steps.generate-ldflags.outputs.ldflags }}
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Generate ld flags
         id: generate-ldflags
         run: |
@@ -74,9 +74,9 @@ jobs:
       fail-fast: true
     name: Go ${{ needs.get-go-version.outputs.go-version }} ${{ matrix.goos }} ${{ matrix.goarch }} build
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Setup go
-        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version-file: ".go-version"
       - name: Determine artifact basename
@@ -117,13 +117,13 @@ jobs:
           echo "RPM_PACKAGE=$(basename out/*.rpm)" >> "$GITHUB_ENV"
           echo "DEB_PACKAGE=$(basename out/*.deb)" >> "$GITHUB_ENV"
       - if: ${{ matrix.goos == 'linux' }}
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: ${{ env.RPM_PACKAGE }}
           path: out/${{ env.RPM_PACKAGE }}
           if-no-files-found: error
       - if: ${{ matrix.goos == 'linux' }}
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: ${{ env.DEB_PACKAGE }}
           path: out/${{ env.DEB_PACKAGE }}
@@ -141,7 +141,7 @@ jobs:
       version: ${{ needs.get-product-version.outputs.product-version }}
     name: Docker ${{ matrix.arch }} default release build
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Docker Build (Action)
         uses: hashicorp/actions-docker-build@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
       GO_TAGS: ''
       GO111MODULE: 'on'
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version-file: ".go-version"
       - name: Setup golangci-lint
@@ -21,8 +21,8 @@ jobs:
   check-deps-go:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version-file: ".go-version"
       - run: make check-mod
@@ -32,8 +32,8 @@ jobs:
       GO_TAGS: ''
       GO111MODULE: 'on'
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version-file: ".go-version"
       - run: make test
@@ -43,8 +43,8 @@ jobs:
       GO_TAGS: ''
       GO111MODULE: 'on'
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
           go-version-file: ".go-version"
       - run: make dev

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -4,24 +4,30 @@
 # notarized.
 # Failures are reported to slack.
 name: Nightly Release
+
 on:
   schedule:
     # Runs against the default branch every day overnight
     - cron: "18 3 * * *"
+
   workflow_dispatch:
+
 jobs:
   # Build a fresh set of artifacts
   build-artifacts:
     uses: ./.github/workflows/build.yml
+
   github-release:
     needs: build-artifacts
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+
       - name: Download built artifacts
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           path: out/
+
       # Set BUILD_OUTPUT_LIST to out\<project>-<version>.<fileext>\*,out\...
       # This is needed to attach the build artifacts to the GitHub Release
       - name: Set BUILD_OUTPUT_LIST
@@ -30,6 +36,7 @@ jobs:
           sed 's:.*:out/&/*:' < tmp.txt > tmp2.txt
           echo "BUILD_OUTPUT_LIST=$(tr '\n' ',' < tmp2.txt | perl -ple 'chop')" >> "$GITHUB_ENV"
           rm -rf tmp.txt && rm -rf tmp2.txt
+
       - name: Advance nightly tag
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
@@ -50,6 +57,7 @@ jobs:
               ref: "refs/tags/nightly",
               sha: context.sha
             })
+
       # This will create a new GitHub Release called `nightly`
       # If a release with this name already exists, it will overwrite the existing data
       - name: Create a nightly GitHub prerelease
@@ -65,13 +73,15 @@ jobs:
           removeArtifacts: true
           draft: false
           token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish nightly GitHub prerelease
         uses: eregon/publish-release@01df127f5e9a3c26935118e22e738d95b59d10ce # v1.0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           release_id: ${{ steps.create_prerelease.outputs.id }}
-  # Send a slack notification if either job defined above fails
+
+# Send a slack notification if either job defined above fails
   slack-notify:
     needs:
       - build-artifacts
@@ -79,12 +89,13 @@ jobs:
     if: always() && (needs.build-artifacts.result == 'failure' || needs.github-release.result == 'failure')
     runs-on: ubuntu-latest
     steps:
-      - name: Notify Slack on failed Backport PRs
-        uses: hashicorp/actions-slack-status@v1
+      - name: Notify Slack on Nightly Release Failure
+        uses: hashicorp/actions-slack-status@1a3f63b30bd476aee1f3bd6f9d8f2aacc4f14d81 # v2.0.1
         with:
           failure-message: |-
             :x::moon::nomad-sob: Levant Nightly Release *FAILED* on
           status: failure
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+
 permissions:
   contents: write

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -17,9 +17,9 @@ jobs:
     needs: build-artifacts
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
       - name: Download built artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           path: out/
       # Set BUILD_OUTPUT_LIST to out\<project>-<version>.<fileext>\*,out\...
@@ -31,7 +31,7 @@ jobs:
           echo "BUILD_OUTPUT_LIST=$(tr '\n' ',' < tmp2.txt | perl -ple 'chop')" >> "$GITHUB_ENV"
           rm -rf tmp.txt && rm -rf tmp2.txt
       - name: Advance nightly tag
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -54,7 +54,7 @@ jobs:
       # If a release with this name already exists, it will overwrite the existing data
       - name: Create a nightly GitHub prerelease
         id: create_prerelease
-        uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5 # v1.13.0
+        uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # v1.14.0
         with:
           name: nightly
           artifacts: "${{ env.BUILD_OUTPUT_LIST }}"
@@ -66,7 +66,7 @@ jobs:
           draft: false
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish nightly GitHub prerelease
-        uses: eregon/publish-release@46913fa2b3f7edc7345ae3c17f6d1b093a54916d # v1.0.5
+        uses: eregon/publish-release@01df127f5e9a3c26935118e22e738d95b59d10ce # v1.0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
Part of removing any actions that might still use the Node 16 actions.

* actions/checkout v4.1.1 ==> v4.1.6
* actions/download-artifact v3.0.2 ==> v4.1.7
* actions/github-script v6.4.1 ==> v7.0.1
* actions/setup-go v4.1.0 ==> v5.0.1
* actions/upload-artifact v4.3.1 ==> v4.3.3
* eregon/publish-release v1.0.5 ==> v1.0.6
* ncipollo/release-action v1.13.0 ==> v1.14.0

* hashicorp/actions-docker-build v1.0.0 ==> v2.0.0
* hashicorp/actions-generate-metadata v1.0.0 ==> v1.1.1
* hashicorp/actions-go-build v0.1.9 ==> v1.0.0
* hashicorp/actions-slack-status v1.0.0 ==> v2.0.1
