### PR TITLE
Make Levant deploys namespace-aware for detecting existing Nomad jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 
 # devbuild compiles the binary
 # -----------------------------------
-FROM golang:1.17 AS devbuild
+FROM golang:1.21 AS devbuild
 
 # Disable CGO to make sure we build static binaries
 ENV CGO_ENABLED=0

--- a/levant/deploy.go
+++ b/levant/deploy.go
@@ -476,7 +476,7 @@ func (l *levantDeployment) dynamicGroupCountUpdater() error {
 
 	// Gather information about the current state, if any, of the job on the
 	// Nomad cluster.
-	rJob, _, err := l.nomad.Jobs().Info(*l.config.Template.Job.Name, &nomad.QueryOptions{})
+	rJob, _, err := l.nomad.Jobs().Info(*l.config.Template.Job.Name, &nomad.QueryOptions{Namespace: *l.config.Template.Job.Namespace})
 
 	// This is a hack due to GH-1849; we check the error string for 404, which
 	// indicates the job is not running, not that there was an error in the API


### PR DESCRIPTION
This change uses the namespace from the rendered Levant template in order to lookup any pre-existing job with the same name in the Nomad API.

Fixes hashicorp/levant#553